### PR TITLE
add optint and eio as dependencies

### DIFF
--- a/tcpip.opam
+++ b/tcpip.opam
@@ -55,6 +55,8 @@ depends: [
   "ipaddr-cstruct" {with-test}
   "lru" {>= "0.3.0"}
   "metrics"
+  "optint"
+  "eio"
 ]
 depopts: [
   "ocaml-freestanding"


### PR DESCRIPTION
optint is for [`src/tcp/dune`](https://github.com/patricoferris/mirage-tcpip/blob/34d4761a05da6c49b9a63f714ebe2fb2dfcc7036/src/tcp/dune#L8)